### PR TITLE
Display user/group info and actions on same line

### DIFF
--- a/web/css/grouphub.css
+++ b/web/css/grouphub.css
@@ -1342,6 +1342,11 @@ footer a {
 .edit_group_container ul.users > div:last-child > li:last-child {
     margin-bottom: 20px; }
 
+.edit_group_container ul.users li div:first-child {
+    float:left;
+    max-width: 90%;
+}
+
 .edit_group_container ul.users li p {
     margin: 0 60px 0 0;
     padding: 0;
@@ -1367,7 +1372,8 @@ footer a {
 /* line 248, _edit_group.scss */
 .edit_group_container ul.users li a {
     float: right;
-    display: inline-block; }
+}
+
 /* line 251, _edit_group.scss */
 .edit_group_container ul.users li a i {
     background-color: white;
@@ -1375,7 +1381,7 @@ footer a {
     border: 1px solid #a6a6a6;
     border-radius: 50%;
     padding: 2px 4px;
-    margin: 6px 15px 0 5px; }
+    margin: 0 15px }
 /* line 262, _edit_group.scss */
 .edit_group_container #group_deletion_confirmation {
     position: absolute;


### PR DESCRIPTION
@Frankniesten, ik kan even niet meer terugvinden of en in welk issue we het geconstateerd hadden maar dit is een fix om te zorgen dat in een lijst van groepen of gebruikers de knoppen rechts naast de naam etc. verschijven i.p.v. op een nieuwe regel.