### PR TITLE
Fix searching for groups in add members from group screen

### DIFF
--- a/web/js/scripts.js
+++ b/web/js/scripts.js
@@ -30,7 +30,7 @@ var grouphub = (function ($) {
             $searchResults = $searchContainer.next('ul');
 
         var url = $searchResults.data('url');
-        var type = $searchContainer.find("input[name='search-type']:checked").val();
+        var type = $searchContainer.find("select[name=search-type]").val();
         if (type === 'group') {
             url = url.replace('users', 'groups');
         }


### PR DESCRIPTION
@Frankniesten @hermanvand Volgens hadden jullie het zelf nog niet gespot maar door restyling van de keuze 'zoeken op gebruiler/groep' was het zoeken van groepen stuk. Deze PR fixt dat.