### PR TITLE
Only show the extra user info button for semi-formal groups

### DIFF
--- a/app/Resources/views/popups/group_users.html.twig
+++ b/app/Resources/views/popups/group_users.html.twig
@@ -10,7 +10,7 @@
         {% endif %}
 
         <div class="user-name">
-            {% if user.extraAttributes|length > 0 %}
+            {% if group.semiFormal and user.extraAttributes|length > 0 %}
                 <a class="btn-circular toggle-extra-user-info" href="#"><span
                         class="fa fa-angle-double-down"></span></a>
             {% endif %}


### PR DESCRIPTION
The button should not be shown if the user isn't permitted to view the info.